### PR TITLE
Temporarily disable the painting of saeule.png

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -38,12 +38,12 @@ startx = 169
 starty = 830
 priority = 2
 
-[[structure]]
-name = "saeule"
-file = "images/saeule.png"
-startx = 431
-starty = 829
-priority = 2
+# [[structure]]
+# name = "saeule"
+# file = "images/saeule.png"
+# startx = 431
+# starty = 829
+# priority = 2
 
 [[structure]]
 name = "sprich_deutsch_schriftzug"


### PR DESCRIPTION
Da die LGBTQ Community gerade komplett verdrängt wurde und so die Säule immer direkt zerstört wird, würde es mehr Sinn ergeben die Pixel (für den Moment) woanders einzusetzen.