### PR TITLE
disable mahluna (rvnx)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -456,12 +456,12 @@ starty = 647
 priority = 2
 
 
-[[structure]]
-name = "mahluna"
-file = "images/mahluna.png"
-startx = 1485
-starty = 1172
-priority = 2
+# [[structure]]
+# name = "mahluna"
+# file = "images/mahluna.png"
+# startx = 1485
+# starty = 1172
+# priority = 2
 
 [[structure]]
 name = "pogostuck"


### PR DESCRIPTION
Im Discord chat meinte jemand dass rvnx währe bereits verschwunden und es hätte keinen Sinn mehr das mit Bots an die Stelle zu platzieren. Es ist allerdings noch da also muss man das erstmal nicht mergen.
Falls es doch mal weg muss sollte das hier ein schneller fix sein.