### PR TITLE
Zeitweise Elphi aus dem Bot kommentiert

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -477,9 +477,9 @@ startx = 389
 starty = 1971
 priority = 2
 
-[[structure]]
-name = "elphi"
-file = "images/elphi.png"
-startx = 1699
-starty = 1136
-priority = 2
+# [[structure]]
+# name = "elphi"
+# file = "images/elphi.png"
+# startx = 1699
+# starty = 1136
+# priority = 2


### PR DESCRIPTION
Habe Zeitweise die Elphi aus dem Bot genommen, das sie vollkommen übermalt wurde und wir aktuell nur Boot-Ressourcen verschwenden.