### PR TITLE
Verschieben des Mahluna-Logos

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -462,7 +462,7 @@ priority = 2
 [[structure]]
 name = "mahluna"
 file = "images/mahluna.png"
-startx = 1485
+startx = 1489
 starty = 1172
 priority = 2
 


### PR DESCRIPTION
Damit die[ VShojo Community](https://www.reddit.com/r/VShojo/comments/tvvp35/vshojo_square/) Platz bekommt, ihre Figuren links vom Logo fertig zu malen, wurde im [Mahluna Discord](https://discord.com/channels/583810899840598016/960271675620986890/960540160284586024) vorgeschlagen, das Logo nach rechts zu verschieben, wo im Moment ungenutzte Fläche ist. 
