### PR TITLE
lower priority for blue auto instead of autobahn

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -103,7 +103,7 @@ name = "autobahn"
 file = "images/autobahn.png"
 startx = 539
 starty = 838
-priority = 1
+priority = 2
 
 [[structure]]
 name = "verspaetung"
@@ -462,7 +462,7 @@ name = "auto"
 file = "images/auto.png"
 startx = 775
 starty = 1124
-priority = 2
+priority = 1
 
 [[structure]]
 name = "rvnx"


### PR DESCRIPTION
Wir greifen die Cussy (von HasanAbi) nicht an, auch auf unseren Autos, Bot Protection ist runter gestellt. [254a63839dab880f3a31781f6a23706ab130e44f ](https://github.com/placeDE/pixel/commit/254a63839dab880f3a31781f6a23706ab130e44f) hatte allerdings die Autobahn in der Priorität verringert.